### PR TITLE
Feature/story props

### DIFF
--- a/sustAInableEducation-backend/Migrations/20250107090938_AddStoryProps.Designer.cs
+++ b/sustAInableEducation-backend/Migrations/20250107090938_AddStoryProps.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using sustAInableEducation_backend.Repository;
 
@@ -11,9 +12,11 @@ using sustAInableEducation_backend.Repository;
 namespace sustAInableEducation_backend.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250107090938_AddStoryProps")]
+    partial class AddStoryProps
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/sustAInableEducation-backend/Migrations/20250107090938_AddStoryProps.cs
+++ b/sustAInableEducation-backend/Migrations/20250107090938_AddStoryProps.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace sustAInableEducation_backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStoryProps : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Prompt",
+                table: "Story",
+                newName: "Topic");
+
+            migrationBuilder.AddColumn<int>(
+                name: "TargetGroup",
+                table: "Story",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TargetGroup",
+                table: "Story");
+
+            migrationBuilder.RenameColumn(
+                name: "Topic",
+                table: "Story",
+                newName: "Prompt");
+        }
+    }
+}

--- a/sustAInableEducation-backend/Models/Story.cs
+++ b/sustAInableEducation-backend/Models/Story.cs
@@ -13,14 +13,22 @@ namespace sustAInableEducation_backend.Models
 
         [MaxLength(256)]
         public string? Title { get; set; }
-        public string Prompt { get; set; } = null!;
+        public string Topic { get; set; } = null!;
         public uint Length { get; set; }
         public float Temperature { get; set; }
         public float TopP { get; set; }
         public float TotalImpact { get; set; } = 0;
+        public TargetGroup TargetGroup { get; set; }
 
         [JsonIgnore]
         public bool IsComplete => Parts.Count >= Length;
+    }
+
+    public enum TargetGroup
+    {
+        PrimarySchool,
+        MiddleSchool,
+        HighSchool,
     }
 
     public class StoryResult

--- a/sustAInableEducation-backend/Repository/AIService.cs
+++ b/sustAInableEducation-backend/Repository/AIService.cs
@@ -81,7 +81,7 @@ namespace sustAInableEducation_backend.Repository
 
             var chatMessages = new List<ChatMessage>
             {
-                new() { Role = ValidRoles.System, Content = story.Prompt },
+                //new() { Role = ValidRoles.System, Content = story.Prompt },
                 new() { Role = ValidRoles.User, Content = "Alle Teilnehmer sind bereit, beginne mit dem ersten Teil der Geschichte." }
             };
 

--- a/sustAInableEducation-backend/Repository/AIService.cs
+++ b/sustAInableEducation-backend/Repository/AIService.cs
@@ -79,9 +79,25 @@ namespace sustAInableEducation_backend.Repository
             ArgumentNullException.ThrowIfNull(story);
             if (story.Length == 0) throw new ArgumentException("Story has set no length");
 
+            string targetGroupString = story.TargetGroup switch
+            {
+                TargetGroup.PrimarySchool => "Die Teilnehmer, welche deine Geschichte lesen, sind Volksschüler im Alter von 6 bis 10 Jahren. Pass deinen Stil an diese Zielgruppe an und verwende einfache Sprache mit kurzen und klaren Sätzen. Achte darauf, dass die Geschichte einen direkten Bezug auf die Lebenswelt der Schüler hat, damit diese sich leicht in diese versetzen können.",
+                TargetGroup.MiddleSchool => "Die Teilnehmer, welche deine Geschichte lesen, sind Schüler der Sekundarstufe eins im Alter von 11 bis 14 Jahren. Pass deinen Stil an diese Zielgruppe und verwende einen passend anspruchsvollen Wortschatz und Satzbau. Die Entscheidungspunkte sollen moralische Dilemmas und praxisnahe Probleme beschreiben.",
+                TargetGroup.HighSchool => "Die Teilnehmer, welche deine Geschichte lesen, sind Schüler der Sekundarstufe zwei im Alter von 15 bis 19 Jahren. Pass deinen Stil an diese Zielgruppe an und verwende eine anspruchsvollere Sprache mit komplexeren Satzstrukturen und Fachbegriffen. Die Geschichte soll die globale und wissenschaftliche Relevanz von Nachhaltigkeit aufzeigen. Entscheidungspunkte sollen kritisches Denken und die Analyse verschiedener Perspektiven fördern.",
+                _ => throw new ArgumentException("Invalid target group")
+            };
+            string systemPrompt = "Du bist ein Geschichtenerzähler, welcher eine interaktive und textbasierte Geschichte erstellt. Deine Geschichte ist immersiv, spannend und soll Teilnehmer zum Nachdenken über das Thema Nachhaltigkeit anstoßen. " +
+                "Deine Geschichte wird interaktiv über Entscheidungspunkte gesteuert. " +
+                $"Deine Geschichte umfasst genau {story.Length} Entscheidungspunkte. " +
+                "Entscheidungspunkte sind essenziell, denn sie bestimmen, wie die Geschichte weiter verläuft. Über Entscheidungspunkte stimmt immer eine Gruppe an Teilnehmer ab. Ein Entscheidungspunkt besteht aus vier Optionen, wie die Geschichte verlaufen wird. Nicht jede Option muss einen besonders guten Einfluss auf die Geschichte haben und soll die Teilnehmer vor diversen Aufgaben und Problemen stellen, welche die Teilnehmer durch ihre Entscheidungen lösen müssen. Der Einfluss einer Option wird gemessen mittels eines Werts zwischen -1 und 1. Eine Option mit negativem Einfluss würde näher an -1 liegen, und eine Option mit positivem Einfluss würde näher an 1 liegen. Wenn du bei einem Entscheidungspunkt in der Geschichte angelangt bist, präsentiere die vier Optionen und warte auf die Entscheidung der Teilnehmer." +
+                targetGroupString +
+                "Ebenso benötigt jede Geschichte einen Titel. Der Titel deiner Geschichte soll die Teilnehmer fesseln und Lust auf die kommende Geschichte machen, aber achte auch darauf, dass der Titel die Geschichte passend beschreibt. Füge zu jedem Abschnitt einen Zwischentitel hinzu, dieser soll den folgenden Abschnitt beschreiben." +
+                story.Topic +
+                "Antworte ausschließlich im gültigen JSON-Format, damit deine Antworten den Teilnehmern richtig dargestellt werden können. Jede deiner Antworten hat den identen JSON-Aufbau. Erstens den Titel der Geschichte, dieser bleibt immer gleich und der Zwischentitel des Abschnittes. Darauf folgt die Geschichte, also der Abschnitt der Geschichte, welchen du geschrieben hast. Dann die vier Optionen des Entscheidungspunkts in einem Array. Wenn es der letzte Teil der Geschichte ist, befülle das Array, mit den Optionen, mit leeren Inhalten, welche trotzdem valide sind. Hier ist die JSON-Struktur, welche immer geliefert werden soll: { \"title\": \"Titel der Geschichte\", \"intertitle\": \"Zwischentitel des Abschnitt\", \"story\": \"Aktueller Teil der Geschichte basierend auf den bisherigen Entscheidungen.\", \"options\": [ { \"impact\": \"Wert zwischen -1 und 1\", \"text\": \"Option 1 Beschreibung\" }, { \"impact\": \"Wert zwischen -1 und 1\", \"text\": \"Option 2 Beschreibung\" } , { \"impact\": \"Wert zwischen -1 und 1\", \"text\": \"Option 3 Beschreibung\" } , { \"impact\": \"Wert zwischen -1 und 1\", \"text \": \"Option 4 Beschreibung\" } ] }";
+
             var chatMessages = new List<ChatMessage>
             {
-                //new() { Role = ValidRoles.System, Content = story.Prompt },
+                new() { Role = ValidRoles.System, Content = systemPrompt },
                 new() { Role = ValidRoles.User, Content = "Alle Teilnehmer sind bereit, beginne mit dem ersten Teil der Geschichte." }
             };
 


### PR DESCRIPTION
This pull request introduces changes to the `sustAInableEducation-backend` project to enhance the `Story` model by adding a `TargetGroup` property and renaming the `Prompt` property to `Topic`. These changes are reflected in the migration files, model definitions, and service logic.

Key changes include:

### Database Migrations
* Added a new migration to rename the `Prompt` column to `Topic` and add a new `TargetGroup` column to the `Story` table.
* Updated the `ApplicationDbContextModelSnapshot` to reflect the new `TargetGroup` and `Topic` properties in the `Story` entity. [[1]](diffhunk://#diff-ab62a838c945f00b42e4d1505c7fd84bdfabaf7393e6b545e831394937f9d64bL394-R395) [[2]](diffhunk://#diff-ab62a838c945f00b42e4d1505c7fd84bdfabaf7393e6b545e831394937f9d64bR407-R410)

### Model Updates
* Modified the `Story` model to include a new `TargetGroup` enum property and renamed the `Prompt` property to `Topic`.

### Service Logic
* Updated the `RebuildChatMessages` method in `AIService` to generate a system prompt based on the `TargetGroup` property and use the new `Topic` property.