### PR TITLE
add missing break statement

### DIFF
--- a/sustAInableEducation-backend/Repository/AIService.cs
+++ b/sustAInableEducation-backend/Repository/AIService.cs
@@ -196,6 +196,7 @@ namespace sustAInableEducation_backend.Repository
                 try
                 {
                     endPart = GetStoryPart(assistantContent).Item1;
+                    break;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
This pull request includes a small change to the `sustAInableEducation-backend/Repository/AIService.cs` file. The change adds a `break` statement to the `try` block within the `public async Task<StoryResult> GenerateResult(Story story)` method to ensure the loop terminates after successfully getting the story part.