### PR TITLE
Impact updates

### DIFF
--- a/sustAInableEducation-backend/Hubs/SpaceHub.cs
+++ b/sustAInableEducation-backend/Hubs/SpaceHub.cs
@@ -48,10 +48,11 @@ namespace sustAInableEducation_backend.Hubs
             }
 
             await Groups.AddToGroupAsync(Context!.ConnectionId, _spaceId.ToString());
-            _context.SpaceParticipant.Find(_spaceId, _userId)!.IsOnline = true;
+            var participtant = _context.SpaceParticipant.Find(_spaceId, _userId)!;
+            participtant.IsOnline = true;
             await _context.SaveChangesAsync();
 
-            await SendMessage(MessageType.UserJoined, _userId);
+            await SendMessage(MessageType.UserJoined, participtant);
             await base.OnConnectedAsync();
         }
 
@@ -67,9 +68,16 @@ namespace sustAInableEducation_backend.Hubs
             await base.OnDisconnectedAsync(exception);
         }
 
-        private async Task SendMessage(string type, object? message = null)
+        private async Task SendMessage(string type, object? message1 = null, object? message2 = null)
         {
-            await Clients.Group(_spaceId.ToString()).SendAsync(type, message);
+            if (message2 != null)
+            {
+                await Clients.Group(_spaceId.ToString()).SendAsync(type, message1, message2);
+            }
+            else
+            {
+                await Clients.Group(_spaceId.ToString()).SendAsync(type, message1);
+            }
         }
 
         public async Task GeneratePart()
@@ -202,7 +210,7 @@ namespace sustAInableEducation_backend.Hubs
                     .SetProperty(x => x.Impact, x => x.Impact + x.VoteImpact)
                     .SetProperty(x => x.VoteImpact, x => null));
             await _context.SaveChangesAsync();
-            await SendMessage(MessageType.ChoiceSet, number);
+            await SendMessage(MessageType.ChoiceSet, number, story.TotalImpact);
         }
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `SpaceHub` class in the `sustAInableEducation-backend/Hubs` directory. The changes primarily focus on improving the handling of participant information and enhancing the `SendMessage` method to support multiple messages.

The most important changes include:

### Participant Handling:

* Modified `OnConnectedAsync` to store the retrieved participant in a variable before updating its `IsOnline` status and sending a message with the participant object. (`[sustAInableEducation-backend/Hubs/SpaceHub.csL51-R55](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbL51-R55)`)

### Message Sending Enhancements:

* Updated `SendMessage` method to accept an additional optional message parameter and send both messages if the second parameter is provided. (`[sustAInableEducation-backend/Hubs/SpaceHub.csL70-R80](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbL70-R80)`)
* Updated `SetChoice` method to use the enhanced `SendMessage` method, sending both the choice number and the total impact. (`[sustAInableEducation-backend/Hubs/SpaceHub.csL205-R213](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbL205-R213)`)