### PR TITLE
Bugfix/story null title

### DIFF
--- a/sustAInableEducation-frontend/components/EcoSpaceListEntry.vue
+++ b/sustAInableEducation-frontend/components/EcoSpaceListEntry.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="w-full mb-2 p-2 rounded-md cursor-pointer" :class="model ? 'bg-slate-300' : 'bg-slate-200'" @click="clickEvent">
         <div class="flex justify-between items-center">
-            <span>{{ props.ecoSpace.story.title }}</span>
+            <span>{{ displayTitle() }}</span>
             <Button variant="text" class="!rounded-full aspect-square !p-1" @click="toggleMenu">
                 <Icon name="ic:baseline-more-vert" class="aspect-square size-6 bg-black" />
             </Button>
@@ -59,6 +59,14 @@ function clickEvent() {
 
 function deleteEvent() {
     emit('delete', props.ecoSpace.id);
+}
+
+function displayTitle() {
+    if(props.ecoSpace.story.title) {
+        return props.ecoSpace.story.title
+    } else {
+        return "[Neuer EcoSpace]"
+    }
 }
 
 </script>

--- a/sustAInableEducation-frontend/pages/ecospaces/index.vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/index.vue
@@ -283,7 +283,16 @@ const selectedSpace = ref<EcoSpace>();
 const searchInput = ref('');
 
 const searchedSpaces = computed(() => {
-    return sortedSpaces.value.filter(space => space.story.title.toLowerCase().includes(searchInput.value.toLowerCase()));
+    return sortedSpaces.value.filter(space => {
+        if(space.story.title) {
+            return space.story.title.toLowerCase().includes(searchInput.value.toLowerCase())
+        } else {
+            if(searchInput.value !== "") {
+                return false
+            }
+            return true
+        }
+    });
 });
 
 const filteredSpaces = computed<EcoSpace[]>(() => {


### PR DESCRIPTION
This pull request includes changes to improve the handling of EcoSpace titles in the `sustAInableEducation-frontend` project. The main updates involve displaying a default title when an EcoSpace title is missing and ensuring the search functionality accounts for EcoSpaces without titles.

### Enhancements to EcoSpace title handling:

* [`sustAInableEducation-frontend/components/EcoSpaceListEntry.vue`](diffhunk://#diff-ace204b00a1509b8211ec1f027e4bacfac7e6b8baddee1b8b3d859c148c48088L4-R4): Modified the template to use the new `displayTitle` method, which returns either the EcoSpace title or a default placeholder if the title is missing. Added the `displayTitle` method implementation. [[1]](diffhunk://#diff-ace204b00a1509b8211ec1f027e4bacfac7e6b8baddee1b8b3d859c148c48088L4-R4) [[2]](diffhunk://#diff-ace204b00a1509b8211ec1f027e4bacfac7e6b8baddee1b8b3d859c148c48088R64-R71)

### Improvements to search functionality:

* [`sustAInableEducation-frontend/pages/ecospaces/index.vue`](diffhunk://#diff-b386f649fb08d078b447af40bcfedfd351f9f1f1188e6af6ac2c85ea54ea3f6aL286-R295): Updated the `searchedSpaces` computed property to handle EcoSpaces without titles properly, ensuring they are included in the search results when the search input is empty.