### PR TITLE
Feature/implement story images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 # Diese .gitignore-Datei wurde von Microsoft(R) Visual Studio automatisch erstellt.
 ################################################################################
 
-/sustAInableEducation-backend/wwwroot/Images
+/sustAInableEducation-backend/wwwroot/images

--- a/sustAInableEducation-backend/Controllers/SpacesController.cs
+++ b/sustAInableEducation-backend/Controllers/SpacesController.cs
@@ -81,7 +81,8 @@ namespace sustAInableEducation_backend.Controllers
                     TopP = spaceReq.Story.TopP,
                     TargetGroup = spaceReq.Story.TargetGroup,
                 },
-                VotingTimeSeconds = spaceReq.VotingTimeSeconds
+                VotingTimeSeconds = spaceReq.VotingTimeSeconds,
+                IsImageGenerationEnabled = spaceReq.IsImageGenerationEnabled,
             };
             _context.Space.Add(space);
             await _context.SaveChangesAsync();

--- a/sustAInableEducation-backend/Migrations/20250122115410_AddImageGenerationDisableOption.Designer.cs
+++ b/sustAInableEducation-backend/Migrations/20250122115410_AddImageGenerationDisableOption.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using sustAInableEducation_backend.Repository;
 
@@ -11,9 +12,11 @@ using sustAInableEducation_backend.Repository;
 namespace sustAInableEducation_backend.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250122115410_AddImageGenerationDisableOption")]
+    partial class AddImageGenerationDisableOption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/sustAInableEducation-backend/Migrations/20250122115410_AddImageGenerationDisableOption.cs
+++ b/sustAInableEducation-backend/Migrations/20250122115410_AddImageGenerationDisableOption.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace sustAInableEducation_backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageGenerationDisableOption : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsImageGenerationEnabled",
+                table: "Space",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsImageGenerationEnabled",
+                table: "Space");
+        }
+    }
+}

--- a/sustAInableEducation-backend/Models/Space.cs
+++ b/sustAInableEducation-backend/Models/Space.cs
@@ -15,6 +15,7 @@ namespace sustAInableEducation_backend.Models
         public SpaceAccessCode? AccessCode { get; set; }
 
         public uint VotingTimeSeconds { get; set; } = 10;
+        public bool IsImageGenerationEnabled { get; set; }
         public DateTime CreatedAt { get; set; } = DateTime.Now;
     }
 
@@ -24,5 +25,7 @@ namespace sustAInableEducation_backend.Models
 
         [Range(10, 30)]
         public uint VotingTimeSeconds { get; set; } = 10;
+
+        public bool IsImageGenerationEnabled { get; set; } = true;
     }
 }

--- a/sustAInableEducation-backend/Repository/AIService.cs
+++ b/sustAInableEducation-backend/Repository/AIService.cs
@@ -577,15 +577,18 @@ namespace sustAInableEducation_backend.Repository
             {
                 throw new AIException("Failed to deserialize response content", e);
             }
-            String filePath;
+            string folderName, fileName;
             try
             {
-                var directoryPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "images");
+                var wwwRootPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot");
+                folderName = "images";
+                var directoryPath = Path.Combine(wwwRootPath, folderName);
                 if (!Directory.Exists(directoryPath))
                 {
                     Directory.CreateDirectory(directoryPath);
                 }
-                filePath = Path.Combine(directoryPath, $"{Guid.NewGuid()}.png");
+                fileName = $"{Guid.NewGuid()}.png";
+                var filePath = Path.Combine(directoryPath, fileName);
                 byte[] imageBytes = Convert.FromBase64String(base64String);
                 using (var ms = new MemoryStream(imageBytes))
                 {
@@ -600,7 +603,7 @@ namespace sustAInableEducation_backend.Repository
                 throw new AIException("Failed to save image", e);
             }
 
-            return filePath;
+            return Path.Combine("/", folderName, fileName).Replace("\\", "/");
         }
 
         public Task<Quiz> GenerateQuiz(Story story, QuizRequest config)

--- a/sustAInableEducation-backend/Repository/AIService.cs
+++ b/sustAInableEducation-backend/Repository/AIService.cs
@@ -580,7 +580,7 @@ namespace sustAInableEducation_backend.Repository
             String filePath;
             try
             {
-                var directoryPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "Images");
+                var directoryPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "images");
                 if (!Directory.Exists(directoryPath))
                 {
                     Directory.CreateDirectory(directoryPath);


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable image generation for stories in the `sustAInableEducation-backend` project. The changes include updates to several files to support this feature, including modifications to the database schema, controller, hub, and model classes.

### New Feature: Image Generation Control

* [`sustAInableEducation-backend/Controllers/SpacesController.cs`](diffhunk://#diff-3c07d29e6db5a6e0cb57c48f7d0175af62e7a894b55e8d7ab0b74f572511c602L84-R85): Added a new property `IsImageGenerationEnabled` to the `Space` object when creating a new space.
* `sustAInableEducation-backend/Hubs/SpaceHub.cs`: 
  * Added a new message type `ImageGenerated` to notify clients when an image is generated.
  * Updated the `GeneratePart` method to check if image generation is enabled and generate images accordingly. [[1]](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbL88-R90) [[2]](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbR131-R144)
* [`sustAInableEducation-backend/Migrations/20250122115410_AddImageGenerationDisableOption.cs`](diffhunk://#diff-617774aca37ca9e9f9a112ca15f199b991d4f066aa7983875abb7c5dcfe66a9dR1-R29): Created a new migration to add the `IsImageGenerationEnabled` column to the `Space` table in the database.
* [`sustAInableEducation-backend/Migrations/ApplicationDbContextModelSnapshot.cs`](diffhunk://#diff-ab62a838c945f00b42e4d1505c7fd84bdfabaf7393e6b545e831394937f9d64bR328-R330): Updated the model snapshot to include the new `IsImageGenerationEnabled` property.
* `sustAInableEducation-backend/Models/Space.cs`: 
  * Added the `IsImageGenerationEnabled` property to the `Space` class.
  * Added the `IsImageGenerationEnabled` property to the `SpaceRequest` class with a default value of `true`.
* `sustAInableEducation-backend/Repository/AIService.cs`: 
  * Refactored the `GenerateStoryImage` method to improve file path handling and return a web-accessible path. [[1]](diffhunk://#diff-571a2a82bebf1b34b519bacacbbb68c984059cbee7095cd352d929361be39ac8L580-R591) [[2]](diffhunk://#diff-571a2a82bebf1b34b519bacacbbb68c984059cbee7095cd352d929361be39ac8L603-R606)