### PR TITLE
fix story completion check at start voting

### DIFF
--- a/sustAInableEducation-backend/Hubs/SpaceHub.cs
+++ b/sustAInableEducation-backend/Hubs/SpaceHub.cs
@@ -152,7 +152,7 @@ namespace sustAInableEducation_backend.Hubs
                 throw new HubException("Unauthorized");
             }
             var space = (await _context.SpaceWithStory.FirstOrDefaultAsync(e => e.Id == _spaceId))!;
-            if (space.Story.IsComplete)
+            if (space.Story.Result != null)
             {
                 throw new HubException("Story is complete");
             }


### PR DESCRIPTION
This pull request includes a minor change to the `StartVoting` method in the `SpaceHub` class to improve the logic for checking if a story is complete.

* [`sustAInableEducation-backend/Hubs/SpaceHub.cs`](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbL155-R155): Modified the condition from checking if `space.Story.IsComplete` to `space.Story.Result != null` to determine if a story is complete.