### PR TITLE
Bugfix/login redirect

### DIFF
--- a/sustAInableEducation-frontend/nuxt.config.ts
+++ b/sustAInableEducation-frontend/nuxt.config.ts
@@ -44,6 +44,9 @@ export default defineNuxtConfig({
       hostUrl: process.env.HOST_URL
     }
   },
+  routeRules: {
+    '/ecospaces/*': { ssr: false }
+  },
   modules: [
     '@primevue/nuxt-module',
     '@nuxtjs/google-fonts',

--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -193,6 +193,8 @@ await $fetch(`${runtime.public.apiUrl}/account`, {
     onResponse: (response) => {
         if (response.response.ok) {
             myUserId.value = response.response._data.id
+        } else {
+            router.push('/login')
         }
     },
 })
@@ -415,6 +417,7 @@ async function getSpace() {
         headers: useRequestHeaders(['cookie']),
         onResponse: (response) => {
             if (response.response.ok) {
+                console.log(response.response._data)
                 space.value = response.response._data
                 if (parts.value.length > 0) {
                     enableStart.value = false


### PR DESCRIPTION
This pull request includes several changes to the `sustAInableEducation-frontend` project, focusing on routing, error handling, and debugging improvements. The most important changes are listed below:

### Routing Enhancements:
* [`sustAInableEducation-frontend/nuxt.config.ts`](diffhunk://#diff-938107944fc084e556782360f54f3cc1c380c9c5356755a11e3df3957517847bR47-R49): Added route rules to disable server-side rendering for the `/ecospaces/*` path.

### Error Handling Improvements:
* `sustAInableEducation-frontend/pages/ecospaces/[id].vue`: Added a redirection to the login page if the account fetch response is not OK. ([sustAInableEducation-frontend/pages/ecospaces/[id].vueR196-R197](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2R196-R197))

### Debugging Enhancements:
* `sustAInableEducation-frontend/pages/ecospaces/[id].vue`: Added a console log statement to output the response data in the `getSpace` function for debugging purposes. ([sustAInableEducation-frontend/pages/ecospaces/[id].vueR420](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2R420))