### PR TITLE
add v-if to voting indicator to only show when voting

### DIFF
--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -12,7 +12,7 @@
                         <Icon name="ic:baseline-person-add" class="size-5" />
                     </template>
                 </Button>
-                <div class="font-bold text-xl absolute w-full flex justify-start sm:justify-center items-center">
+                <div v-if="isVoting" class="font-bold text-xl absolute w-full flex justify-start sm:justify-center items-center">
                     Abstimmungszeit</div>
                 <Button label="Teilnehmer" :badge="space?.participants.length.toString()" @click="showUserDialog" />
             </div>


### PR DESCRIPTION
This pull request includes a change to the `sustAInableEducation-frontend/pages/ecospaces/[id].vue` file. The change introduces a conditional rendering for the "Abstimmungszeit" text, making it only visible when the `isVoting` condition is true.

* `sustAInableEducation-frontend/pages/ecospaces/[id].vue`: Added a `v-if` directive to conditionally render the "Abstimmungszeit" text based on the `isVoting` condition. ([sustAInableEducation-frontend/pages/ecospaces/[id].vueL15-R15](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2L15-R15))