### PR TITLE
bugfix/divider-overlap

### DIFF
--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -20,7 +20,7 @@
                 class="panel w-full h-[45rem] rounded-xl relative border-solid border-slate-300 border-2 flex flex-col justify-center">
                 <div class="hostcontrols w-full flex justify-end absolute top-0 right-0 mr-8 mt-4"
                     v-if="role === 'host'">
-                    <div class="bg-white">
+                    <div class="bg-white z-10">
                         <Button label="Abstimmung starten" @click="startVoting" size="small"
                             :disabled="disableStartVoteButton" />
                     </div>


### PR DESCRIPTION
This pull request includes a small change to the `sustAInableEducation-frontend/pages/ecospaces/[id].vue` file. The change adds a `z-10` class to the `div` element within the `hostcontrols` section to ensure proper stacking order for the button when the user role is 'host'. ([sustAInableEducation-frontend/pages/ecospaces/[id].vueL23-R23](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2L23-R23))