### PR TITLE
Bugfix/story panel height

### DIFF
--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -17,7 +17,7 @@
                 <Button label="Teilnehmer" :badge="space?.participants.length.toString()" @click="showUserDialog" />
             </div>
             <div
-                class="panel w-full flex-1 rounded-xl relative border-solid border-slate-300 border-2 flex flex-col justify-center">
+                class="panel w-full flex-1 rounded-xl relative border-solid border-slate-300 border-2 flex flex-col justify-start">
                 <div class="hostcontrols w-full flex justify-end absolute top-0 right-0 mr-8 mt-4"
                     v-if="role === 'host'">
                     <div class="bg-white z-10">
@@ -25,7 +25,7 @@
                             :disabled="disableStartVoteButton" />
                     </div>
                 </div>
-                <div class="content h-[32rem] mt-4 mx-4 overflow-y-scroll overflow-x-hidden" ref="contentDiv">
+                <div class="content h-[32rem] mt-4 mx-4 overflow-y-scroll overflow-x-hidden bg-red-500" ref="contentDiv">
 
                     <div v-for="part, index in space?.story.parts" class="px-4 pb-4 pt-0" ref="partsRef">
                         

--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -17,7 +17,7 @@
                 <Button label="Teilnehmer" :badge="space?.participants.length.toString()" @click="showUserDialog" />
             </div>
             <div
-                class="panel w-full flex-1 rounded-xl relative border-solid border-slate-300 border-2 flex flex-col justify-start">
+                class="panel w-full flex-1 rounded-xl relative border-solid border-slate-300 pb-72 sm:pb-0 border-2 flex flex-col justify-start">
                 <div class="hostcontrols w-full flex justify-end absolute top-0 right-0 mr-8 mt-4"
                     v-if="role === 'host'">
                     <div class="bg-white z-10">
@@ -118,7 +118,7 @@
                         </Button>
                     </div>
                 </div>
-                <div class="controls absolute w-full bottom-0 bg-slate-50 p-4 rounded-xl flex flex-col" v-if="role === 'host'">
+                <div class="controls absolute w-full bottom-0 bg-slate-50 p-4 rounded-bl-xl rounded-br-xl flex flex-col" v-if="role === 'host'">
                     <Divider />
                     <div class="timer">
                         <Timer class="sm:hidden" v-model="timerValue" />
@@ -145,7 +145,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="controls absolute w-full bottom-0 bg-slate-50 flex flex-col p-4 rounded-xl text-xl" v-else>
+                <div class="controls absolute w-full bottom-0 bg-slate-50 flex flex-col p-4 rounded-bl-xl rounded-br-xl text-xl" v-else>
                     <Divider />
                     <div class="timer">
                         <Timer class="sm:hidden" v-model="timerValue" />

--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -17,7 +17,7 @@
                 <Button label="Teilnehmer" :badge="space?.participants.length.toString()" @click="showUserDialog" />
             </div>
             <div
-                class="panel w-full h-[45rem] rounded-xl relative border-solid border-slate-300 border-2 flex flex-col justify-center">
+                class="panel w-full flex-1 rounded-xl relative border-solid border-slate-300 border-2 flex flex-col justify-center">
                 <div class="hostcontrols w-full flex justify-end absolute top-0 right-0 mr-8 mt-4"
                     v-if="role === 'host'">
                     <div class="bg-white z-10">
@@ -118,7 +118,7 @@
                         </Button>
                     </div>
                 </div>
-                <div class="controls flex flex-col m-4" v-if="role === 'host'">
+                <div class="controls absolute w-full bottom-0 bg-slate-50 p-4 rounded-xl flex flex-col" v-if="role === 'host'">
                     <Divider />
                     <div class="timer">
                         <Timer class="sm:hidden" v-model="timerValue" />
@@ -145,7 +145,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="controls flex flex-col m-4 text-xl" v-else>
+                <div class="controls absolute w-full bottom-0 bg-slate-50 flex flex-col p-4 rounded-xl text-xl" v-else>
                     <Divider />
                     <div class="timer">
                         <Timer class="sm:hidden" v-model="timerValue" />

--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -25,7 +25,7 @@
                             :disabled="disableStartVoteButton" />
                     </div>
                 </div>
-                <div class="content h-[32rem] mt-4 mx-4 overflow-y-scroll overflow-x-hidden bg-red-500" ref="contentDiv">
+                <div class="content h-[32rem] mt-4 mx-4 overflow-y-scroll overflow-x-hidden" ref="contentDiv">
 
                     <div v-for="part, index in space?.story.parts" class="px-4 pb-4 pt-0" ref="partsRef">
                         


### PR DESCRIPTION
This pull request includes changes to the layout and styling of the `ecospaces` page in the `sustAInableEducation-frontend` project. The main focus of the changes is to improve the user interface for different roles.

Styling and layout improvements:

* Updated the `panel` class to use `flex-1` for flexible height and adjusted padding for better responsiveness. (`sustAInableEducation-frontend/pages/ecospaces/[id].vue`, [sustAInableEducation-frontend/pages/ecospaces/[id].vueL20-R20](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2L20-R20))
* Modified the `controls` class for the `host` role to be positioned absolutely at the bottom with new background and padding styles. (`sustAInableEducation-frontend/pages/ecospaces/[id].vue`, [sustAInableEducation-frontend/pages/ecospaces/[id].vueL121-R121](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2L121-R121))
* Adjusted the `controls` class for non-host roles to match the new styling, ensuring consistent appearance. (`sustAInableEducation-frontend/pages/ecospaces/[id].vue`, [sustAInableEducation-frontend/pages/ecospaces/[id].vueL148-R148](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2L148-R148))