### PR TITLE
Bugfix/remove coreadmin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ################################################################################
 
 /sustAInableEducation-backend/wwwroot/images
+/wwwroot/images

--- a/sustAInableEducation-backend/Program.cs
+++ b/sustAInableEducation-backend/Program.cs
@@ -65,12 +65,9 @@ builder.Services.AddRouting(options => options.LowercaseUrls = true);
 
 builder.Services.AddTransient<IAIService, AIService>();
 
-builder.Services.AddCoreAdmin("Admin");
-
 var app = builder.Build();
 
 app.UseStaticFiles();
-app.MapDefaultControllerRoute();
 
 app.UseCors(AllowFrontendOrigin);
 

--- a/sustAInableEducation-backend/Repository/DataSeeder.cs
+++ b/sustAInableEducation-backend/Repository/DataSeeder.cs
@@ -45,16 +45,6 @@ namespace sustAInableEducation_backend.Repository
             {
                 await _roleManager.CreateAsync(new IdentityRole("Admin"));
             }
-            if (!await _context.Users.AnyAsync(u => u.UserName == _config["AdminEmail"]))
-            {
-                var user = new ApplicationUser
-                {
-                    UserName = _config["AdminEmail"],
-                    Email = _config["AdminEmail"]
-                };
-                await _userManager.CreateAsync(user, _config["AdminPassword"]!);
-                await _userManager.AddToRoleAsync(user, "Admin");
-            }
         }
     }
 }

--- a/sustAInableEducation-backend/sustAInableEducation-backend.csproj
+++ b/sustAInableEducation-backend/sustAInableEducation-backend.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
-    <PackageReference Include="CoreAdmin" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />


### PR DESCRIPTION
This pull request focuses on the removal of the CoreAdmin package and related code from the `sustAInableEducation-backend` project. The most important changes include deleting the CoreAdmin service registration, removing user seeding for the admin role, and updating the project file to exclude the CoreAdmin package.

Removal of CoreAdmin package and related code:

* [`sustAInableEducation-backend/Program.cs`](diffhunk://#diff-565f704761a2b8e06770161e4e20b799b6a0b9b8b58762446cb09e1192e9f56aL68-L73): Removed the `builder.Services.AddCoreAdmin("Admin");` line and the `app.MapDefaultControllerRoute();` line.
* [`sustAInableEducation-backend/Repository/DataSeeder.cs`](diffhunk://#diff-c1409d2a8a2909207a73d780982e20516329b65dc2e2415b4d5fb725fdcf6c62L48-L57): Deleted the block of code responsible for seeding an admin user.
* [`sustAInableEducation-backend/sustAInableEducation-backend.csproj`](diffhunk://#diff-9353440f1dcaa4e32ee0de9e9b72be5317099f8cefc8794dc909fcf8abced66fL13): Removed the `CoreAdmin` package reference.