### PR TITLE
Bugfix/story-mobile-responsibility

### DIFF
--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -17,7 +17,7 @@
                 <Button label="Teilnehmer" :badge="space?.participants.length.toString()" @click="showUserDialog" />
             </div>
             <div
-                class="panel w-full flex-1 rounded-xl relative border-solid border-slate-300 pb-72 sm:pb-0 border-2 flex flex-col justify-start">
+                class="panel w-full flex-1 rounded-xl relative border-solid border-slate-300 sm:pb-0 border-2 flex flex-col justify-start" :class="'pb-['+ controlHeight + 'px]'">
                 <div class="hostcontrols w-full flex justify-end absolute top-0 right-0 mr-8 mt-4"
                     v-if="role === 'host'">
                     <div class="bg-white z-10">
@@ -118,7 +118,7 @@
                         </Button>
                     </div>
                 </div>
-                <div class="controls absolute w-full bottom-0 bg-slate-50 p-4 rounded-bl-xl rounded-br-xl flex flex-col" v-if="role === 'host'">
+                <div ref="hostControls" class="controls absolute w-full bottom-0 bg-slate-50 p-4 rounded-bl-xl rounded-br-xl flex flex-col" v-if="role === 'host'">
                     <Divider />
                     <div class="timer">
                         <Timer class="sm:hidden" v-model="timerValue" />
@@ -145,7 +145,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="controls absolute w-full bottom-0 bg-slate-50 flex flex-col p-4 rounded-bl-xl rounded-br-xl text-xl" v-else>
+                <div ref="userControls" class="controls absolute w-full bottom-0 bg-slate-50 flex flex-col p-4 rounded-bl-xl rounded-br-xl text-xl" v-else>
                     <Divider />
                     <div class="timer">
                         <Timer class="sm:hidden" v-model="timerValue" />
@@ -186,6 +186,17 @@ const percentages = ref([0, 0, 0, 0])
 const showPercentages = ref(false)
 
 const myUserId = ref('')
+
+const hostControls = ref<HTMLDivElement | null>(null)
+const userControls = ref<HTMLDivElement | null>(null)
+
+const controlHeight = computed(() => {
+    if (role.value === 'host' && hostControls.value) {
+        return hostControls.value.offsetHeight
+    } else if (userControls.value) {
+        return userControls.value.offsetHeight
+    }   
+}) 
 
 await $fetch(`${runtime.public.apiUrl}/account`, {
     credentials: 'include',


### PR DESCRIPTION
This pull request includes changes to the `sustAInableEducation-frontend/pages/ecospaces/[id].vue` file to improve the handling of dynamic control heights and add references to host and user controls. The most important changes include modifying the class bindings for dynamic padding, adding references to control elements, and computing the control height based on the role.

Improvements to dynamic control handling:

* Modified the class binding for the panel to include dynamic padding based on the computed `controlHeight`. (`sustAInableEducation-frontend/pages/ecospaces/[id].vue`) ([sustAInableEducation-frontend/pages/ecospaces/[id].vueL20-R20](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2L20-R20))

References to control elements:

* Added `ref="hostControls"` to the host controls div to reference it in the script. (`sustAInableEducation-frontend/pages/ecospaces/[id].vue`) ([sustAInableEducation-frontend/pages/ecospaces/[id].vueL121-R121](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2L121-R121))
* Added `ref="userControls"` to the user controls div to reference it in the script. (`sustAInableEducation-frontend/pages/ecospaces/[id].vue`) ([sustAInableEducation-frontend/pages/ecospaces/[id].vueL148-R148](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2L148-R148))

Computed control height:

* Introduced `hostControls` and `userControls` refs and computed `controlHeight` based on the role and the height of the respective control element. (`sustAInableEducation-frontend/pages/ecospaces/[id].vue`) ([sustAInableEducation-frontend/pages/ecospaces/[id].vueR190-R200](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2R190-R200))