### PR TITLE
Bugfix/register-elements

### DIFF
--- a/sustAInableEducation-frontend/pages/register.vue
+++ b/sustAInableEducation-frontend/pages/register.vue
@@ -5,11 +5,9 @@
             <Toast />
             <div
                 class="bg-slate-50 shadow-xl flex justify-between flex-col rounded-xl items-center p-8 w-full max-w-md mx-4">
-                <h1 class="text-3xl font-bold mb-4">Login</h1>
+                <h1 class="text-3xl font-bold mb-4">Registrierung</h1>
                 <Form v-slot="$form" :initialValues :resolver @submit="onFormSubmit"
                     class="flex flex-col gap-4 !w-full sm:w-56">
-                    {{ $form.valid }}
-
                     <div>
                         <FloatLabel variant="in" class="flex flex-col">
                             <InputText v-model="formRefs.email.value" name="email" type="email" fluid />
@@ -34,10 +32,6 @@
                         </FloatLabel>
                         <Message v-if="$form.confirmPassword?.invalid" severity="error" size="small" class="mt-2">{{
                             $form.confirmPassword.error?.message }}</Message>
-                    </div>
-                    <div class="flex items-center ml-1">
-                        <Checkbox name="saveLogin" v-model="saveLogin" value="saveLogin" inputId="saveLogin" />
-                        <label for="saveLogin" class="ml-2 cursor-pointer">Eingeloggt bleiben</label>
                     </div>
                     <Button type="submit" label="Registrieren" />
                 </Form>
@@ -71,8 +65,6 @@ const initialValues = reactive({
     password: '',
     confirmPassword: ''
 });
-
-const saveLogin = ref(false)
 
 const resolver = ({ values }: { values: Register }) => {
     const errors: RegisterError = {


### PR DESCRIPTION
This pull request includes changes to the `sustAInableEducation-frontend/pages/register.vue` file to update the registration page's text and remove unnecessary form elements.

Text updates:

* Changed the heading text from "Login" to "Registrierung" to correctly reflect the purpose of the page.

Form simplification:

* Removed the "Eingeloggt bleiben" (stay logged in) checkbox and its associated label from the registration form.
* Removed the `saveLogin` reference from the initial values and the reactive state.