### PR TITLE
save generated image paths

### DIFF
--- a/sustAInableEducation-backend/Hubs/SpaceHub.cs
+++ b/sustAInableEducation-backend/Hubs/SpaceHub.cs
@@ -131,6 +131,7 @@ namespace sustAInableEducation_backend.Hubs
                 if (space.IsImageGenerationEnabled)
                 {
                     story.Result!.Image = await _ai.GenerateStoryImage(story);
+                    await _context.SaveChangesAsync();
                     await SendMessage(MessageType.ImageGenerated, story.Result!.Image);
                 }
             }
@@ -140,6 +141,7 @@ namespace sustAInableEducation_backend.Hubs
                 if (space.IsImageGenerationEnabled)
                 {
                     story.Parts.Last().Image = await _ai.GenerateStoryImage(story);
+                    await _context.SaveChangesAsync();
                     await SendMessage(MessageType.ImageGenerated, story.Parts.Last().Image);
                 }
             }


### PR DESCRIPTION
This pull request includes changes to the `GeneratePart` method in the `SpaceHub` class to ensure that changes are saved to the database after generating story images.

Changes to `GeneratePart` method:

* [`sustAInableEducation-backend/Hubs/SpaceHub.cs`](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbR134): Added calls to `SaveChangesAsync` after generating story images to ensure that the changes are persisted in the database. [[1]](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbR134) [[2]](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbR144)