### PR TITLE
Bugfix/wrong timer values

### DIFF
--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -418,6 +418,8 @@ function startTimer(expirationStr: string) {
         timerValue.value.percent = Math.round((timerValue.value.time / timerValue.value.initialValue) * 100)
 
         if (timerValue.value.time <= 0) {
+            timerValue.value.time = 0
+            timerValue.value.percent = Math.round((timerValue.value.time / timerValue.value.initialValue) * 100)
             isVoting.value = false
             clearInterval(timerInterval)
         }

--- a/sustAInableEducation-frontend/pages/ecospaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/[id].vue
@@ -411,13 +411,17 @@ function startTimer(expirationStr: string) {
     let expirationDate = Date.parse(expirationStr)
 
     timerInterval = setInterval(function () {
-
+        /*
         let now = new Date().getTime()
         let distance = expirationDate - now
         timerValue.value.time = Math.floor(distance / 1000)
         timerValue.value.percent = Math.round((timerValue.value.time / timerValue.value.initialValue) * 100)
+        */
 
-        if (timerValue.value.time <= 0) {
+        timerValue.value.time -= 1
+        timerValue.value.percent = Math.round((timerValue.value.time / timerValue.value.initialValue) * 100)
+
+        if (timerValue.value.time <= 0) {2
             timerValue.value.time = 0
             timerValue.value.percent = Math.round((timerValue.value.time / timerValue.value.initialValue) * 100)
             isVoting.value = false


### PR DESCRIPTION
This pull request includes a change to the `startTimer` function in the `sustAInableEducation-frontend/pages/ecospaces/[id].vue` file. The update simplifies the timer countdown logic by directly decrementing the `time` value and recalculating the `percent` value.

Key change:

* Simplified the timer countdown logic by removing the calculation of `distance` and directly decrementing `timerValue.value.time` in the `setInterval` function. Additionally, ensured that `timerValue.value.time` does not go below zero and recalculated `percent` accordingly. ([sustAInableEducation-frontend/pages/ecospaces/[id].vueL414-R426](diffhunk://#diff-df445aefd11fa22f5c1159456e255153740c072febaa60db4ba22c8332e6fff2L414-R426))