### PR TITLE
bugfix/mobile-overview-scroll

### DIFF
--- a/sustAInableEducation-frontend/components/MobileSidebar.vue
+++ b/sustAInableEducation-frontend/components/MobileSidebar.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="sidebar-container w-full absolute h-full mt-32 bg-white z-10" v-if="model">
-    <div class="sidebar w-full h-full flex-col overflow-y-scroll flex">
+  <div class="sidebar-container w-full flex absolute h-full pt-16 pb-3 bg-red-500  z-10" v-if="model">
+    <div class="sidebar flex-1 w-full bg-blue-200 flex-col overflow-y-scroll flex">
       <div id="sidebar-header">
         <div class="w-full flex items-center justify-end py-2">
           <div @click="emit('toggleSidebar')" class="bg-slate-400 flex items-center opacity-80 justify-center p-2 pr-5 cursor-pointer rounded-tl-xl rounded-bl-xl">

--- a/sustAInableEducation-frontend/layouts/default.vue
+++ b/sustAInableEducation-frontend/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="flex flex-col h-screen">
-        <header class="absolute z-10">
+        <header class="absolute z-20">
             <Header />
         </header>
         <main class="h-full">


### PR DESCRIPTION
This pull request includes changes to the `sustAInableEducation-frontend` project to update the styling of the `MobileSidebar` component and adjust the z-index of the header in the default layout. The most important changes include modifications to the sidebar container and sidebar classes in `MobileSidebar.vue`, and the z-index update in `default.vue`.

Styling updates:

* [`sustAInableEducation-frontend/components/MobileSidebar.vue`](diffhunk://#diff-74d013907ff3913e72a8aa420b91894e489df7584c606daef13d4c07e6ca5bc1L2-R3): Updated the `sidebar-container` class to use padding and a red background color, and the `sidebar` class to use a blue background color.

Layout adjustments:

* [`sustAInableEducation-frontend/layouts/default.vue`](diffhunk://#diff-9e2a15ef2e84a01c00a8596e9d503f7607045eb44d70bbc7e7c0a065d75a9c07L3-R3): Changed the z-index of the header from 10 to 20 to ensure it appears above other elements.