### PR TITLE
fix mobilesidebar background colors

### DIFF
--- a/sustAInableEducation-frontend/components/MobileSidebar.vue
+++ b/sustAInableEducation-frontend/components/MobileSidebar.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="sidebar-container w-full flex absolute h-full pt-16 pb-3 bg-red-500  z-10" v-if="model">
-    <div class="sidebar flex-1 w-full bg-blue-200 flex-col overflow-y-scroll flex">
+  <div class="sidebar-container w-full flex absolute h-full pt-16 pb-3 z-10 bg-white" v-if="model">
+    <div class="sidebar flex-1 w-full flex-col overflow-y-scroll flex">
       <div id="sidebar-header">
         <div class="w-full flex items-center justify-end py-2">
           <div @click="emit('toggleSidebar')" class="bg-slate-400 flex items-center opacity-80 justify-center p-2 pr-5 cursor-pointer rounded-tl-xl rounded-bl-xl">


### PR DESCRIPTION
This pull request includes a small change to the `sustAInableEducation-frontend/components/MobileSidebar.vue` file. The change modifies the background color of the sidebar container and removes an unnecessary background color from a child div. 

Changes in `MobileSidebar.vue`:

* Changed the background color of the `sidebar-container` class from `bg-red-500` to `bg-white`.
* Removed the `bg-blue-200` class from the `sidebar` div.