### PR TITLE
Bugfix/overview space data

### DIFF
--- a/sustAInableEducation-frontend/pages/ecospaces/index.vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/index.vue
@@ -121,6 +121,10 @@
                                             {{ selectedSpace.story.length }}
                                         </p>
                                         <p class="mb-2">
+                                            <span class="font-bold">Abstimmungszeit:</span>
+                                            {{ selectedSpace.votingTimeSeconds + ' Sekunden' }}
+                                        </p>
+                                        <p class="mb-2">
                                             <span class="font-bold">Zielgruppe:</span>
                                             {{ getTargetgroup(selectedSpace.story.targetGroup) }}
                                         </p>

--- a/sustAInableEducation-frontend/pages/ecospaces/index.vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/index.vue
@@ -122,7 +122,7 @@
                                         </p>
                                         <p class="mb-2">
                                             <span class="font-bold">Zielgruppe:</span>
-                                            TODO
+                                            {{ getTargetgroup(selectedSpace.story.targetGroup) }}
                                         </p>
                                     </div>
                                     <div class="w-full">
@@ -483,6 +483,17 @@ const openDialog = (id: string) => {
 
         }
     });
+}
+
+function getTargetgroup(targetGroup: number) {
+    switch (targetGroup) {
+        case 0:
+            return 'Volksschule';
+        case 1:
+            return 'Sekundarstufe I';
+        default:
+            return 'Sekundarstufe II';
+    }
 }
 </script>
 

--- a/sustAInableEducation-frontend/types/EcoSpace.ts
+++ b/sustAInableEducation-frontend/types/EcoSpace.ts
@@ -37,6 +37,7 @@ export interface Story {
     temperature: number,
     topP: number,
     totalImpact: number,
+    targetGroup: number,
     parts: Array<Part>,
     result: Result | null,
 }


### PR DESCRIPTION
This pull request includes several changes to the `sustAInableEducation-frontend` project, specifically focusing on the `ecospaces` page and the `EcoSpace` type. The most important changes include adding new fields to the UI, implementing a new function to handle target groups, and updating the `Story` interface to include a new property.

### Changes to `ecospaces` page:

* Added a new field to display the voting time in seconds. (`sustAInableEducation-frontend/pages/ecospaces/index.vue`, [sustAInableEducation-frontend/pages/ecospaces/index.vueR123-R129](diffhunk://#diff-b386f649fb08d078b447af40bcfedfd351f9f1f1188e6af6ac2c85ea54ea3f6aR123-R129))
* Implemented the `getTargetgroup` function to map numeric target group values to their corresponding educational levels. (`sustAInableEducation-frontend/pages/ecospaces/index.vue`, [sustAInableEducation-frontend/pages/ecospaces/index.vueR491-R501](diffhunk://#diff-b386f649fb08d078b447af40bcfedfd351f9f1f1188e6af6ac2c85ea54ea3f6aR491-R501))

### Changes to `EcoSpace` type:

* Updated the `Story` interface to include a new `targetGroup` property. (`sustAInableEducation-frontend/types/EcoSpace.ts`, [sustAInableEducation-frontend/types/EcoSpace.tsR40](diffhunk://#diff-1e4549e5d8fc40d54c1a6a2f12cedb08bae3de5e7ec9b3c6ccf9b5837d1040f1R40))