### PR TITLE
send username when user joined

### DIFF
--- a/sustAInableEducation-backend/Hubs/SpaceHub.cs
+++ b/sustAInableEducation-backend/Hubs/SpaceHub.cs
@@ -50,7 +50,7 @@ namespace sustAInableEducation_backend.Hubs
             }
 
             await Groups.AddToGroupAsync(Context!.ConnectionId, _spaceId.ToString());
-            var participtant = _context.SpaceParticipant.Find(_spaceId, _userId)!;
+            var participtant = _context.SpaceParticipant.Include(p => p.User).FirstOrDefault(p => p.UserId == _userId && p.SpaceId == _spaceId)!;
             participtant.IsOnline = true;
             await _context.SaveChangesAsync();
 


### PR DESCRIPTION
This pull request includes an important change to the `OnConnectedAsync` method in the `SpaceHub` class to ensure that the `SpaceParticipant` entity is properly loaded with its related `User` entity.

Database query improvement:

* [`sustAInableEducation-backend/Hubs/SpaceHub.cs`](diffhunk://#diff-223916791854e4246d27687b19966c37d923b3470b0d24ad0056815b6467d3cbL53-R53): Modified the query to include the `User` entity when retrieving the `SpaceParticipant` to ensure that the `User` data is available.