### PR TITLE
Bugfix/overview hide delete

### DIFF
--- a/sustAInableEducation-frontend/components/EcoSpaceListEntry.vue
+++ b/sustAInableEducation-frontend/components/EcoSpaceListEntry.vue
@@ -2,7 +2,7 @@
     <div class=" mb-2 p-2 rounded-md cursor-pointer" :class="model ? 'bg-slate-300' : 'bg-slate-200'" @click="clickEvent">
         <div class="flex justify-between items-center">
             <span>{{ displayTitle() }}</span>
-            <Button variant="text" class="!rounded-full aspect-square !p-1" @click="toggleMenu">
+            <Button v-if="showDelete" variant="text" class="!rounded-full aspect-square !p-1" @click="toggleMenu">
                 <Icon name="ic:baseline-more-vert" class="aspect-square size-6 bg-black" />
             </Button>
             <Menu ref="menu" :model="menuItems" :popup="true" class="!rounded-md">
@@ -29,7 +29,7 @@ const model = defineModel<boolean>();
 
 const emit = defineEmits(['click', 'delete']);
 
-const props = defineProps<{ ecoSpace: EcoSpace }>();
+const props = defineProps<{ ecoSpace: EcoSpace, showDelete: boolean }>();
 
 const menu = ref();
 

--- a/sustAInableEducation-frontend/pages/ecospaces/index.vue
+++ b/sustAInableEducation-frontend/pages/ecospaces/index.vue
@@ -67,6 +67,7 @@
                     </div>
                     <div id="sidebar-content">
                         <EcoSpaceListEntry v-for="ecoSpace in searchedSpaces" :ecoSpace="ecoSpace"
+                            :show-delete="myUserId === ecoSpace.participants.find(participant => participant.isHost)?.userId"
                             v-on:delete="openDialog" v-model="spaceRefsById[ecoSpace.id].value"
                             v-on:click="selectSpaceById(ecoSpace.id)" />
                         <NuxtLink to="/configuration">


### PR DESCRIPTION
This pull request includes changes to the `EcoSpaceListEntry` component and its usage in the `ecospaces/index.vue` page. The main objective is to conditionally display the delete button based on user permissions.

Enhancements to conditional UI rendering:

* [`sustAInableEducation-frontend/components/EcoSpaceListEntry.vue`](diffhunk://#diff-ace204b00a1509b8211ec1f027e4bacfac7e6b8baddee1b8b3d859c148c48088L5-R5): Added a `v-if` directive to the delete button to conditionally render it based on the `showDelete` prop.
* [`sustAInableEducation-frontend/components/EcoSpaceListEntry.vue`](diffhunk://#diff-ace204b00a1509b8211ec1f027e4bacfac7e6b8baddee1b8b3d859c148c48088L32-R32): Updated the `props` definition to include a new `showDelete` boolean property.

Integration with user permissions:

* [`sustAInableEducation-frontend/pages/ecospaces/index.vue`](diffhunk://#diff-b386f649fb08d078b447af40bcfedfd351f9f1f1188e6af6ac2c85ea54ea3f6aR70): Passed the `showDelete` prop to the `EcoSpaceListEntry` component, setting it to true if the current user is the host of the ecoSpace.