### PR TITLE
Bugfix/configuration time estimation size

### DIFF
--- a/sustAInableEducation-frontend/pages/configuration.vue
+++ b/sustAInableEducation-frontend/pages/configuration.vue
@@ -146,7 +146,7 @@
                                                 </div>
                                             </Message>
                                             <Dialog v-model:visible="showEstimatedTimeDialog" modal
-                                                header="Berechnung der Zeitschätzung" class="w-full max-w-[650px]">
+                                                header="Berechnung der Zeitschätzung" class="w-full max-w-[650px] mx-4">
                                                 <div class="flex flex-col">
                                                     <p>Die Zeitschätzung gibt einen groben Richtwert für die Dauer eines
                                                         EcoSpaces an.

--- a/sustAInableEducation-frontend/pages/configuration.vue
+++ b/sustAInableEducation-frontend/pages/configuration.vue
@@ -146,7 +146,7 @@
                                                 </div>
                                             </Message>
                                             <Dialog v-model:visible="showEstimatedTimeDialog" modal
-                                                header="Berechnung der Zeitschätzung" class="w-full max-w-[45 0px]">
+                                                header="Berechnung der Zeitschätzung" class="w-full max-w-[650px]">
                                                 <div class="flex flex-col">
                                                     <p>Die Zeitschätzung gibt einen groben Richtwert für die Dauer eines
                                                         EcoSpaces an.


### PR DESCRIPTION
This pull request includes a small change to the `sustAInableEducation-frontend/pages/configuration.vue` file. The change adjusts the dialog box's maximum width and adds a margin to improve the layout.

* [`sustAInableEducation-frontend/pages/configuration.vue`](diffhunk://#diff-34591d94a81bd04cac92d6cb7cb81f589550452a77f496e15d4d00a0b7e7106dL149-R149): Modified the `Dialog` component to set the maximum width to 650px and added a margin of 4 units.