### PR TITLE
Bugfix/logged in redirection

### DIFF
--- a/sustAInableEducation-frontend/pages/login.vue
+++ b/sustAInableEducation-frontend/pages/login.vue
@@ -46,10 +46,15 @@ import type { Login, LoginError } from '~/types/login'
 const runtimeConfig = useRuntimeConfig();
 
 const route = useRoute();
+const router = useRouter();
 
 const toast = useToast();
 
 const redirection = route.query.redirect as string | undefined;
+
+const cookieHeaders = useRequestHeaders(['cookie']);
+
+await isLoggedInRequest();
 
 const formRefs = {
     email: ref<string>(''),
@@ -120,5 +125,18 @@ async function login() {
             }
         })
     } catch (e) { }
+}
+
+async function isLoggedInRequest() {
+    await $fetch(`${runtimeConfig.public.apiUrl}/account`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: cookieHeaders,
+        onResponse: (response) => {
+            if (response.response.status === 200) {
+                router.push('/');
+            }
+        }
+    })
 }
 </script>

--- a/sustAInableEducation-frontend/pages/register.vue
+++ b/sustAInableEducation-frontend/pages/register.vue
@@ -50,8 +50,13 @@ import type { Register, RegisterError } from '~/types/register'
 const runtimeConfig = useRuntimeConfig();
 
 const route = useRoute();
+const router = useRouter();
 
 const redirection = route.query.redirect as string | undefined;
+
+const cookieHeaders = useRequestHeaders(['cookie']);
+
+await isLoggedInRequest();
 
 const toast = useToast();
 
@@ -174,6 +179,19 @@ function includesUppercase(str: string) {
 function includesLowercase(str: string) {
     let RegEx = /[a-zäöü]/;
     return !RegEx.test(str);
+}
+
+async function isLoggedInRequest() {
+    await $fetch(`${runtimeConfig.public.apiUrl}/account`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: cookieHeaders,
+        onResponse: (response) => {
+            if (response.response.status === 200) {
+                router.push('/');
+            }
+        }
+    })
 }
 
 </script>


### PR DESCRIPTION
This pull request includes changes to the `login.vue` and `register.vue` files in the `sustAInableEducation-frontend` project. The primary goal of these changes is to add functionality for checking if a user is already logged in and redirecting them to the homepage if they are.

### Additions to login and register pages:

* [`sustAInableEducation-frontend/pages/login.vue`](diffhunk://#diff-04df42599c98475094ab09e2193e674edba08322c772b1607a5392578e753383R49-R58): Added `useRouter`, `useRequestHeaders`, and the `isLoggedInRequest` function to check if the user is logged in and redirect them to the homepage if they are. [[1]](diffhunk://#diff-04df42599c98475094ab09e2193e674edba08322c772b1607a5392578e753383R49-R58) [[2]](diffhunk://#diff-04df42599c98475094ab09e2193e674edba08322c772b1607a5392578e753383R129-R141)
* [`sustAInableEducation-frontend/pages/register.vue`](diffhunk://#diff-93096d7d7a1ffa760857dd47f2053ece6542a3e2e4362a8063a48a7f07e12d02R53-R60): Added `useRouter`, `useRequestHeaders`, and the `isLoggedInRequest` function to check if the user is logged in and redirect them to the homepage if they are. [[1]](diffhunk://#diff-93096d7d7a1ffa760857dd47f2053ece6542a3e2e4362a8063a48a7f07e12d02R53-R60) [[2]](diffhunk://#diff-93096d7d7a1ffa760857dd47f2053ece6542a3e2e4362a8063a48a7f07e12d02R184-R196)