### PR TITLE
Bugfix/space-url-path - redirect fix

### DIFF
--- a/sustAInableEducation-frontend/components/Header.vue
+++ b/sustAInableEducation-frontend/components/Header.vue
@@ -6,7 +6,7 @@
         </NuxtLink>
 
         <div class="flex justify-center items-center">
-            <NuxtLink to="/ecospaces" class="text-white mx-4 text-xl">EcoSpaces</NuxtLink>
+            <NuxtLink to="/spaces" class="text-white mx-4 text-xl">EcoSpaces</NuxtLink>
             <NuxtLink to="/quizzes" class="text-white mx-4 text-xl">Quizzes</NuxtLink>
             <div class="text-white mx-4 text-xl flex justify-center items-center" :class="!(['/login', '/register'].includes(route.path)) ? 'cursor-pointer' : ''" @click="toggleMenu">
                 <Icon name="ic:baseline-account-circle" class="bg-white mx-4 size-10" />

--- a/sustAInableEducation-frontend/nuxt.config.ts
+++ b/sustAInableEducation-frontend/nuxt.config.ts
@@ -52,7 +52,7 @@ export default defineNuxtConfig({
     }
   },
   routeRules: {
-    '/ecospaces/*': { ssr: false }
+    '/spaces/*': { ssr: false }
   },
   modules: [
     '@primevue/nuxt-module',

--- a/sustAInableEducation-frontend/pages/configuration.vue
+++ b/sustAInableEducation-frontend/pages/configuration.vue
@@ -365,7 +365,7 @@ function createSpaceFromSdg(targetGroup: number) {
         },
         onResponse: (response) => {
             if (response.response.ok) {
-                navigateTo(`/ecospaces/${response.response._data.id}`)
+                navigateTo(`/spaces/${response.response._data.id}`)
             } else {
                 loading.value = false;
                 console.error(response.error)
@@ -393,7 +393,7 @@ function createSpaceFromTopic(targetGroup: number) {
         },
         onResponse: (response) => {
             if (response.response.ok) {
-                navigateTo(`/ecospaces/${response.response._data.id}`)
+                navigateTo(`/spaces/${response.response._data.id}`)
             } else {
                 loading.value = false;
                 console.error(response.error)

--- a/sustAInableEducation-frontend/pages/index.vue
+++ b/sustAInableEducation-frontend/pages/index.vue
@@ -63,7 +63,7 @@ function joinEcoSpace(code: string) {
         },
         onResponse: (response) => {
             if (response.response.ok) {
-                navigateTo('/ecospaces/' + response.response._data.id)
+                navigateTo('/spaces/' + response.response._data.id)
             } else {
                 loading.value = false;
                 console.log(loading.value)

--- a/sustAInableEducation-frontend/pages/join/[code].vue
+++ b/sustAInableEducation-frontend/pages/join/[code].vue
@@ -22,7 +22,7 @@ if (import.meta.client) {
     },
     onResponse: (response) => {
       if (response.response.ok) {
-        router.push(`/ecospaces/${response.response._data.id}`)
+        router.push(`/spaces/${response.response._data.id}`)
       } else if (response.response.status === 404) {
         router.push('/')
       } else if (response.response.status === 401) {

--- a/sustAInableEducation-frontend/pages/spaces/index.vue
+++ b/sustAInableEducation-frontend/pages/spaces/index.vue
@@ -104,7 +104,7 @@
                             <span class="text-md">
                                 Dieser EcoSpace wurde noch nicht beendet. Wenn Sie diesen EcoSpace fortsetzen wollen,
                                 können Sie
-                                <NuxtLink class="text-blue-700 hover:text-blue-500 hover:underline font-bold" :to="'/ecospaces/' + selectedSpace.id">hier</NuxtLink>
+                                <NuxtLink class="text-blue-700 hover:text-blue-500 hover:underline font-bold" :to="'/spaces/' + selectedSpace.id">hier</NuxtLink>
                                 klicken um diesem beizutreten.
                             </span>
                         </Message>


### PR DESCRIPTION
This pull request includes several changes to update the URL paths from `/ecospaces` to `/spaces` across various components and files in the `sustAInableEducation-frontend` project. The updates ensure consistency in the URL structure throughout the application.

URL path updates:

* [`sustAInableEducation-frontend/components/Header.vue`](diffhunk://#diff-07e0f63a6f28de8d7133a389aa302fb845953b740d87917aa6387f72ff84770aL9-R9): Changed the `NuxtLink` path from `/ecospaces` to `/spaces`.
* [`sustAInableEducation-frontend/nuxt.config.ts`](diffhunk://#diff-938107944fc084e556782360f54f3cc1c380c9c5356755a11e3df3957517847bL55-R55): Updated the `routeRules` to reflect the new path `/spaces/*` instead of `/ecospaces/*`.
* [`sustAInableEducation-frontend/pages/configuration.vue`](diffhunk://#diff-34591d94a81bd04cac92d6cb7cb81f589550452a77f496e15d4d00a0b7e7106dL368-R368): Modified the `navigateTo` function calls in `createSpaceFromSdg` and `createSpaceFromTopic` to use the new path `/spaces`. [[1]](diffhunk://#diff-34591d94a81bd04cac92d6cb7cb81f589550452a77f496e15d4d00a0b7e7106dL368-R368) [[2]](diffhunk://#diff-34591d94a81bd04cac92d6cb7cb81f589550452a77f496e15d4d00a0b7e7106dL396-R396)
* [`sustAInableEducation-frontend/pages/index.vue`](diffhunk://#diff-c336460c9df36d6255c598c6ff8f9b1d09578441a663bb40be6ce9ab6502c72eL66-R66): Updated the `navigateTo` function call in `joinEcoSpace` to use the new path `/spaces`.
* `sustAInableEducation-frontend/pages/join/[code].vue`: Changed the `router.push` path in the response handling to `/spaces`. ([sustAInableEducation-frontend/pages/join/[code].vueL25-R25](diffhunk://#diff-da54a36850e3854ae637dcb241a4ebc68fb4ffab3269ebc6a3ae1fe2f25afe05L25-R25))
* [`sustAInableEducation-frontend/pages/spaces/index.vue`](diffhunk://#diff-1c59d3af6f2f828d262c1b3ee46563f50f7d5b9144c32f0eab908a2ee4c0cb0cL107-R107): Updated the `NuxtLink` path in the message component to `/spaces`.