### PR TITLE
Bugfix/page titles

### DIFF
--- a/sustAInableEducation-frontend/pages/configuration.vue
+++ b/sustAInableEducation-frontend/pages/configuration.vue
@@ -190,6 +190,10 @@
 import { Configuration } from '~/types/configuration';
 import { SdgAsset } from '~/types/sdgs';
 
+useHead({
+    title: 'EcoSpace erstellen - sustAInableEducation'
+})
+
 const runtimeConfig = useRuntimeConfig()
 const route = useRoute()
 

--- a/sustAInableEducation-frontend/pages/index.vue
+++ b/sustAInableEducation-frontend/pages/index.vue
@@ -25,6 +25,10 @@
 
 <script setup lang="ts">
 
+useHead({
+    title: 'sustAInableEducation'
+})
+
 const runtimeConfig = useRuntimeConfig()
 const toast = useToast()
 

--- a/sustAInableEducation-frontend/pages/login.vue
+++ b/sustAInableEducation-frontend/pages/login.vue
@@ -45,6 +45,10 @@
 <script setup lang="ts">
 import type { Login, LoginError } from '~/types/login'
 
+useHead({
+    title: 'Anmeldung - sustAInableEducation'
+})
+
 const runtimeConfig = useRuntimeConfig();
 
 const route = useRoute();

--- a/sustAInableEducation-frontend/pages/register.vue
+++ b/sustAInableEducation-frontend/pages/register.vue
@@ -49,6 +49,10 @@
 <script setup lang="ts">
 import type { Register, RegisterError } from '~/types/register'
 
+useHead({
+    title: 'Registrierung - sustAInableEducation'
+})
+
 const runtimeConfig = useRuntimeConfig();
 
 const route = useRoute();

--- a/sustAInableEducation-frontend/pages/spaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/spaces/[id].vue
@@ -208,6 +208,10 @@ const id = route.params.id
 
 const space = ref<EcoSpace | null>(null)
 
+const pageTitle = computed(() => {
+    return `${space.value?.story.title ? space.value?.story.title : 'Neuer EcoSpace'} - sustAInableEducation`
+})
+
 const hasVoted = ref(false)
 const isVoting = ref(false)
 const percentages = ref([0, 0, 0, 0])
@@ -279,6 +283,11 @@ const imageLoading = ref(false)
 const showReloadButton = ref(false)
 
 await getSpace()
+
+useHead({
+    title: pageTitle 
+})
+
 if (parts.value.length > 0) {
     if (parts.value[parts.value.length - 1].choices.some((choice) => choice.numberVotes > 0)) {
         percentages.value = parts.value[parts.value.length - 1].choices.map((choice) => Math.round((choice.numberVotes / parts.value[parts.value.length - 1].choices.reduce((a, b) => a + b.numberVotes, 0)) * 100))

--- a/sustAInableEducation-frontend/pages/spaces/index.vue
+++ b/sustAInableEducation-frontend/pages/spaces/index.vue
@@ -227,6 +227,10 @@
 import type { EcoSpace } from '~/types/EcoSpace';
 import type { OverviewFilter } from '~/types/filter';
 
+useHead({
+    title: 'EcoSpace Übersicht - sustAInableEducation'
+})
+
 const runtimeConfig = useRuntimeConfig();
 const confirmDialog = useConfirm();
 const toast = useToast();


### PR DESCRIPTION
This pull request includes updates to the `sustAInableEducation-frontend` project, primarily focusing on setting the page titles for various pages using the `useHead` function. Below are the most important changes:

Page Title Updates:

* [`sustAInableEducation-frontend/pages/configuration.vue`](diffhunk://#diff-34591d94a81bd04cac92d6cb7cb81f589550452a77f496e15d4d00a0b7e7106dR193-R196): Added a title for the configuration page.
* [`sustAInableEducation-frontend/pages/index.vue`](diffhunk://#diff-c336460c9df36d6255c598c6ff8f9b1d09578441a663bb40be6ce9ab6502c72eR28-R31): Set the title for the index page.
* [`sustAInableEducation-frontend/pages/login.vue`](diffhunk://#diff-04df42599c98475094ab09e2193e674edba08322c772b1607a5392578e753383R48-R51): Set the title for the login page.
* [`sustAInableEducation-frontend/pages/register.vue`](diffhunk://#diff-93096d7d7a1ffa760857dd47f2053ece6542a3e2e4362a8063a48a7f07e12d02R52-R55): Added a title for the registration page.
* `sustAInableEducation-frontend/pages/spaces/[id].vue`: Computed and set a dynamic title for the individual space pages based on the space's story title. ([sustAInableEducation-frontend/pages/spaces/[id].vueR211-R214](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fR211-R214), [sustAInableEducation-frontend/pages/spaces/[id].vueR286-R290](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fR286-R290))
* [`sustAInableEducation-frontend/pages/spaces/index.vue`](diffhunk://#diff-1c59d3af6f2f828d262c1b3ee46563f50f7d5b9144c32f0eab908a2ee4c0cb0cR230-R233): Set the title for the EcoSpace overview page.