### PR TITLE
fix quiz delete

### DIFF
--- a/sustAInableEducation-backend/Controllers/QuizzesController.cs
+++ b/sustAInableEducation-backend/Controllers/QuizzesController.cs
@@ -79,7 +79,7 @@ namespace sustAInableEducation_backend.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteQuiz(Guid id)
         {
-            var quiz = await _context.Quiz.FindAsync(id);
+            var quiz = await _context.QuizWithAll.FirstOrDefaultAsync(q => q.Id == id);
             if (quiz == null)
             {
                 return NotFound();


### PR DESCRIPTION
This pull request includes a change to the `DeleteQuiz` method in the `QuizzesController` class to improve the retrieval of quiz data.

Codebase improvement:

* [`sustAInableEducation-backend/Controllers/QuizzesController.cs`](diffhunk://#diff-c334bfda09f63b921c93a5243a65bcb655559b775c2e0048737a7e6e8c6742b6L82-R82): Modified the `DeleteQuiz` method to use `QuizWithAll.FirstOrDefaultAsync` instead of `Quiz.FindAsync` for fetching quiz data by `id`. This ensures that all related data is included when retrieving the quiz for deletion.