### PR TITLE
remove newlines from image prompt

### DIFF
--- a/sustAInableEducation-backend/Repository/AIService.cs
+++ b/sustAInableEducation-backend/Repository/AIService.cs
@@ -643,6 +643,7 @@ namespace sustAInableEducation_backend.Repository
             {
                 _logger.LogInformation("Fetching assistant content for image prompt");
                 imagePrompt = await FetchAssitantContent(chatMessages, story.Temperature, story.TopP, false);
+                imagePrompt = imagePrompt.Replace("\n", " ");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This pull request includes a small change to the `sustAInableEducation-backend/Repository/AIService.cs` file. The change modifies the `GenerateStoryImage` method to replace newline characters in the `imagePrompt` with spaces.