### PR TITLE
send spaceId with quiz

### DIFF
--- a/sustAInableEducation-backend/Models/Quiz.cs
+++ b/sustAInableEducation-backend/Models/Quiz.cs
@@ -8,7 +8,6 @@ namespace sustAInableEducation_backend.Models
         public Guid Id { get; set; }
         [JsonIgnore]
         public string UserId { get; set; } = null!;
-        [JsonIgnore]
         public Guid SpaceId { get; set; }
 
         public ICollection<QuizQuestion> Questions { get; set; } = new List<QuizQuestion>();


### PR DESCRIPTION
This pull request includes a small change to the `Quiz` class in the `sustAInableEducation-backend/Models/Quiz.cs` file. The change removes the `[JsonIgnore]` attribute from the `SpaceId` property.

* [`sustAInableEducation-backend/Models/Quiz.cs`](diffhunk://#diff-d56ccc7be5d084b2339870a28fd4593c938b271ba1130acaf6409da3d862b175L11): Removed the `[JsonIgnore]` attribute from the `SpaceId` property.