### PR TITLE
Bugfix/start-quiz

### DIFF
--- a/sustAInableEducation-frontend/pages/quizzes/index.vue
+++ b/sustAInableEducation-frontend/pages/quizzes/index.vue
@@ -73,6 +73,9 @@
                                 </div> -->
                             </div>
                         </Panel>
+                        <div class="mb-2 w-full flex justify-center items-center">
+                            <Button label="Quiz starten" size="large" fluid @click="navigateTo(`/quizzes/${selectedQuiz.id}`)"/>
+                        </div>
                         <div class="flex flex-col w-full">
                             <h2 class="text-3xl mb-2">Versuche</h2>
                             <DataTable v-if="selectedQuiz.tries.length > 0" :value="selectedQuiz.tries" class="!w-full !rounded-xl !overflow-hidden">
@@ -102,6 +105,8 @@
 <script setup lang="ts">
 import type { EcoSpace } from '~/types/EcoSpace';
 import type { Quiz } from '~/types/Quiz';
+
+const showDelete = ref(false)
 
 const requestHeaders = useRequestHeaders(['cookie']);
 const runtimeConfig = useRuntimeConfig();


### PR DESCRIPTION
This pull request introduces some new features and improvements to the `sustAInableEducation-frontend/pages/quizzes/index.vue` file. The most important changes include adding a button to start a quiz and a new reactive variable to manage the visibility of delete options.

New features and improvements:

* Added a "Quiz starten" button to allow users to start a selected quiz. The button is styled to be large and fluid and is centered within its container. (`sustAInableEducation-frontend/pages/quizzes/index.vue`)
* Introduced a new reactive variable `showDelete` to manage the visibility of delete options. (`sustAInableEducation-frontend/pages/quizzes/index.vue`)