### PR TITLE
Bugfix/quiz query param

### DIFF
--- a/sustAInableEducation-frontend/pages/quizzes/index.vue
+++ b/sustAInableEducation-frontend/pages/quizzes/index.vue
@@ -18,7 +18,7 @@
                     </div>
                     <div id="sidebar-content">
                         <QuizListEntry v-for="quiz in searchedQuizzes" :quiz="quiz"
-                            v-model="quizRefsById[quiz.id].value" @click="selectQuizById(quiz.id)"
+                            v-model="quizRefsById[quiz.id].value" @click="navigateTo({path: '/quizzes',query: {quizId: quiz.id}});"
                             @delete="openDialog" />
                         <NuxtLink to="/quizzes/configuration">
                             <Button label="Quiz erstellen" rounded size="small" class="w-full !text-">
@@ -38,7 +38,7 @@
 
             <MobileQuizSidebar class="sm:hidden" v-model="showSidebar" :searched-quizzes="searchedQuizzes"
                 :search-input="searchInput" :quizzes="quizzes" :selected-quiz="selectedQuiz"
-                :quiz-refs-by-id="quizRefsById" @open-delete-dialog="openDialog" @select-quiz="selectQuizById"
+                :quiz-refs-by-id="quizRefsById" @open-delete-dialog="openDialog" @select-quiz="(id: number) => navigateTo({path: '/quizzes',query: {quizId: id}})"
                 @toggle-sidebar="showSidebar = !showSidebar" @search-update="updateSearch" />
 
             <div class="content flex-1 h-full overflow-y-scroll w-full">
@@ -105,6 +105,7 @@
 <script setup lang="ts">
 import type { EcoSpace } from '~/types/EcoSpace';
 import type { Quiz } from '~/types/Quiz';
+import Id from './[id].vue';
 
 const showDelete = ref(false)
 
@@ -134,6 +135,10 @@ const quizRefsById = quizzes.value ? quizzes.value.reduce((acc, quiz) => {
     acc[quiz.id] = ref(false);
     return acc;
 }, {} as Record<string, Ref<boolean>>) : {};
+
+if(route.query.quizId && quizzes) {
+    selectQuizById(route.query.quizId as string);
+}
 
 const searchedQuizzes = computed(() => {
     if (quizzes.value === null) return [];


### PR DESCRIPTION
This pull request includes several changes to the `sustAInableEducation-frontend/pages/quizzes/index.vue` file to enhance the quiz selection and navigation functionality. The most important changes include modifying the `selectQuizById` function to support navigation, updating the `selectedQuiz` to be reactive to URL query parameters, and simplifying the `getQuiz` function.

Enhancements to quiz selection and navigation:

* Modified the `selectQuizById` function to support navigation by adding a `navigate` parameter and updating the function to use `navigateTo` when this parameter is true. [[1]](diffhunk://#diff-bf1a312f6333e64cf26ff2dad4beec4a7b73cd9b46e2d5aeba350704b782f9bdL21-R21) [[2]](diffhunk://#diff-bf1a312f6333e64cf26ff2dad4beec4a7b73cd9b46e2d5aeba350704b782f9bdL153-R187)
* Updated the `MobileQuizSidebar` component to use a new `select-quiz` event handler that navigates to the quiz page with the selected quiz ID as a query parameter.
* Changed the `selectedQuiz` to be reactive to the `quizId` query parameter by using `useAsyncData` and `computed` properties for dynamic API URL generation. This ensures the selected quiz is updated when the `quizId` changes.
* Simplified the `getQuiz` function to refresh the selected quiz data using the `refreshSelected` function.

Code improvements:

* Added an import for `Id` from `./[id].vue` to the script setup section.