### PR TITLE
Bugfix/configuration-time-estimation

### DIFF
--- a/sustAInableEducation-frontend/pages/configuration.vue
+++ b/sustAInableEducation-frontend/pages/configuration.vue
@@ -238,7 +238,9 @@ const configFilledOut = computed(() => {
 })
 
 const estimatedTime = computed(() => {
-    let seconds = (decisionPoints.value - 1) * voteTime.value + decisionPoints.value * 90
+    const readingTimePerPoint = 180 // seconds per decision point for reading
+    const votingTimeTotal = (decisionPoints.value - 1) * voteTime.value // total voting time
+    let seconds = votingTimeTotal + decisionPoints.value * readingTimePerPoint
     return `${Math.trunc(seconds / 60)} Minuten` + (seconds % 60 !== 0 ? ` ${seconds % 60} Sekunden` : '')
 })
 


### PR DESCRIPTION
This pull request includes a change to the `estimatedTime` computed property in the `sustAInableEducation-frontend/pages/configuration.vue` file. The change refactors the calculation of estimated time by introducing a new constant for reading time per decision point and separating the voting time calculation.

Improvements to estimated time calculation:

* [`sustAInableEducation-frontend/pages/configuration.vue`](diffhunk://#diff-34591d94a81bd04cac92d6cb7cb81f589550452a77f496e15d4d00a0b7e7106dL241-R243): Added a constant `readingTimePerPoint` to represent the seconds per decision point for reading, and refactored the calculation of `seconds` to separately compute total voting time and reading time per decision point.