### PR TITLE
Bugfix/story-vote-percentages

### DIFF
--- a/sustAInableEducation-frontend/pages/spaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/spaces/[id].vue
@@ -29,7 +29,7 @@
                 <div class="content h-full mt-4 mx-4 overflow-y-scroll overflow-x-hidden" ref="contentDiv">
                     <div v-for="part, index in space?.story.parts" class="px-4 pb-4 pt-0" ref="partsRef">
 
-                        <h2 class="font-bold mb-2" :ref="index === space!.story.parts.length - 1 ? 'lastPart' : ''">{{
+                        <h2 @click="console.log(part.choices)" class="font-bold mb-2" :ref="index === space!.story.parts.length - 1 ? 'lastPart' : ''">{{
                             `${index + 1}:
                             ${part.intertitle}` }}</h2>
                         <p class="mb-4">{{ part.text }}</p>
@@ -595,6 +595,7 @@ function printLogs() {
 
 function getPercentages(part: Part) {
     let sum = part.choices.reduce((a, b) => a + b.numberVotes, 0)
+    if(sum === 0) return [0, 0, 0, 0]
     return part.choices.map((choice) => Math.round((choice.numberVotes / sum) * 100))
 }
 </script>


### PR DESCRIPTION
This pull request includes changes to the `sustAInableEducation-frontend/pages/spaces/[id].vue` file to add a click event for debugging purposes and to handle edge cases in the `getPercentages` function.

Debugging improvements:

* Added a `console.log` statement to the click event on the `h2` element to log `part.choices` for debugging purposes. ([sustAInableEducation-frontend/pages/spaces/[id].vueL32-R32](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fL32-R32))

Edge case handling:

* Modified the `getPercentages` function to return `[0, 0, 0, 0]` if the sum of `part.choices.numberVotes` is zero, preventing division by zero errors. ([sustAInableEducation-frontend/pages/spaces/[id].vueR598](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fR598))