### PR TITLE
Bugfix/reset-timer

### DIFF
--- a/sustAInableEducation-frontend/pages/spaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/spaces/[id].vue
@@ -381,6 +381,7 @@ connection.on("ResultGenerated", async (result: Result) => {
 })
 
 connection.on("VotingStarted", async (expirationStr: string) => {
+    resetTimer()
     hasVoted.value = false
     isVoting.value = true
     showPercentages.value = true


### PR DESCRIPTION
This pull request introduces a small but important change to the `sustAInableEducation-frontend/pages/spaces/[id].vue` file. The change ensures that the voting timer is reset whenever a "VotingStarted" event is triggered.

* `connection.on("VotingStarted", async (expirationStr: string) => {`: Added a call to `resetTimer()` at the start of the event handler to ensure the voting timer is properly reset when a new voting session begins. ([sustAInableEducation-frontend/pages/spaces/[id].vueR384](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fR384))