### PR TITLE
Bugfix/remove debug logs

### DIFF
--- a/sustAInableEducation-frontend/components/InviteDialog.vue
+++ b/sustAInableEducation-frontend/components/InviteDialog.vue
@@ -70,7 +70,6 @@ function copyJoinCode() {
 
 function setCodeTimer() {
     clearInterval(interval.value)
-    console.log(`EXPIRATION: ${props.expirationDate}`)
     let expirationDate = Date.parse(props.expirationDate)
 
     interval.value = setInterval(function () {

--- a/sustAInableEducation-frontend/pages/index.vue
+++ b/sustAInableEducation-frontend/pages/index.vue
@@ -70,7 +70,6 @@ function joinEcoSpace(code: string) {
                 navigateTo('/spaces/' + response.response._data.id)
             } else {
                 loading.value = false;
-                console.log(loading.value)
                 toast.add({
                     severity: 'error',
                     summary: 'Fehler',

--- a/sustAInableEducation-frontend/pages/quizzes/[id].vue
+++ b/sustAInableEducation-frontend/pages/quizzes/[id].vue
@@ -93,7 +93,6 @@ async function handleButtonClick(index: number) {
 }
 
 async function getResult () {
-  console.log(`${runtimeConfig.public.apiUrl}/quizzes/${route.params.id}/try`)
   console.table(selectedAnswers.value)
   await $fetch<{isCorrect: boolean}[]>(`${runtimeConfig.public.apiUrl}/quizzes/${route.params.id}/try`, {
     method: 'POST',

--- a/sustAInableEducation-frontend/pages/quizzes/configuration.vue
+++ b/sustAInableEducation-frontend/pages/quizzes/configuration.vue
@@ -125,18 +125,6 @@ if (error.value && error.value.statusCode === 401) {
   navigateTo(`/login?redirect=${route.fullPath}`)
 }
 
-if (data.value) {
-  console.log("PRE")
-  /* spaces.value = data.value.filter(space => {
-    if (space.story) {
-      return space.story.result !== null
-    }
-    return false
-  }) */
-  console.log("POST2")
-}
-
-
 function formatDate(date: string) {
   return new Date(date).toLocaleDateString('de-DE', { year: 'numeric', month: 'long', day: '2-digit' })
 }

--- a/sustAInableEducation-frontend/pages/spaces/[id].vue
+++ b/sustAInableEducation-frontend/pages/spaces/[id].vue
@@ -29,7 +29,7 @@
                 <div class="content h-full mt-4 mx-4 overflow-y-scroll overflow-x-hidden" ref="contentDiv">
                     <div v-for="part, index in space?.story.parts" class="px-4 pb-4 pt-0" ref="partsRef">
 
-                        <h2 @click="console.log(part.choices)" class="font-bold mb-2" :ref="index === space!.story.parts.length - 1 ? 'lastPart' : ''">{{
+                        <h2 class="font-bold mb-2" :ref="index === space!.story.parts.length - 1 ? 'lastPart' : ''">{{
                             `${index + 1}:
                             ${part.intertitle}` }}</h2>
                         <p class="mb-4">{{ part.text }}</p>
@@ -308,7 +308,6 @@ async function generatePart() {
     try {
         await connection.invoke("GeneratePart")
     } catch (err) {
-        console.log("ALARM GENERATE" + err)
         isLoading.value = false
         showReloadButton.value = true
     }
@@ -413,7 +412,6 @@ connection.on("UserJoined", (user: Participant) => {
 })
 
 connection.on("UserLeft", (userId: string) => {
-    console.log("triggered")
     const selectedUser = space.value!.participants.find((participant) => participant.userId === userId)
     selectedUser!.isOnline = false
 })
@@ -421,7 +419,6 @@ connection.on("UserLeft", (userId: string) => {
 async function startConnection() {
     try {
         await connection.start();
-        console.log("SignalR Connected.");
     } catch (err) {
         router.push('/login?redirect=' + route.fullPath)
     }
@@ -490,13 +487,11 @@ async function getSpace() {
         headers: useRequestHeaders(['cookie']),
         onResponse: (response) => {
             if (response.response.ok) {
-                console.log(response.response._data)
                 space.value = response.response._data
                 if (parts.value.length > 0) {
                     enableStart.value = false
                 }
             } else {
-                console.log("ERROR")
             }
         },
     })
@@ -517,7 +512,6 @@ async function getSpace() {
                     }
                 }
             } else {
-                console.log("ERROR")
             }
         },
     })
@@ -533,7 +527,6 @@ async function getJoinCode() {
                 joinCode.value = response.response._data.code
                 joinExpirationDate.value = response.response._data.expiresAt
             } else {
-                console.log("ERROR")
             }
         },
     })


### PR DESCRIPTION
This pull request focuses on cleaning up the codebase by removing unnecessary `console.log` statements across multiple files in the `sustAInableEducation-frontend` project. These changes improve code readability and maintainability without altering functionality.

### Code cleanup:

* Removed `console.log` statements from `setCodeTimer` in `InviteDialog.vue` to eliminate debug logs related to expiration date.
* Removed `console.log` statements from `joinEcoSpace` in `index.vue` to clean up debugging logs for loading state.
* Removed `console.log` and commented-out code from `handleButtonClick` and other sections in `quizzes/[id].vue` and `configuration.vue` to streamline the quiz-related logic. ([sustAInableEducation-frontend/pages/quizzes/[id].vueL96](diffhunk://#diff-48bad62d3f82446bc6ce655bf553d52a97025300d0749427d0abbbb2ce9c9658L96), [sustAInableEducation-frontend/pages/quizzes/configuration.vueL128-L139](diffhunk://#diff-78aaf8081a8c19444991e326ad2c98c99a55302a6076e78d26077c0ed14686bcL128-L139))
* Removed multiple `console.log` statements from `spaces/[id].vue`, including those in `generatePart`, `getSpace`, `getJoinCode`, and SignalR connection handlers, to declutter space-related functionality. ([sustAInableEducation-frontend/pages/spaces/[id].vueL32-R32](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fL32-R32), [sustAInableEducation-frontend/pages/spaces/[id].vueL311](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fL311), [sustAInableEducation-frontend/pages/spaces/[id].vueL416-L424](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fL416-L424), [sustAInableEducation-frontend/pages/spaces/[id].vueL493-L499](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fL493-L499), [sustAInableEducation-frontend/pages/spaces/[id].vueL520](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fL520), [sustAInableEducation-frontend/pages/spaces/[id].vueL536](diffhunk://#diff-e2c4648f4a09b5d5d52049922d140736e06f4a97d99bd7f00579bab91c52e37fL536))