### PR TITLE
Bugfix/remove try count

### DIFF
--- a/sustAInableEducation-frontend/components/QuizListEntry.vue
+++ b/sustAInableEducation-frontend/components/QuizListEntry.vue
@@ -18,7 +18,6 @@
               </template>
           </Menu>
       </div>
-      <span>Versuche: {{ quiz.tries.length }}</span>
   </div>
 </template>
 


### PR DESCRIPTION
This pull request includes a minor change to the `QuizListEntry.vue` file. The change removes the display of the number of quiz attempts (`quiz.tries.length`) from the component.